### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/languages/textpattern-importer.pot
+++ b/languages/textpattern-importer.pot
@@ -30,7 +30,7 @@ msgstr ""
 #: textpattern-importer.php:85
 msgid ""
 "Howdy! This imports categories, users, posts, comments, and links from any "
-"Textpattern 4.0.2+ into this site."
+"Textpattern >= 4.0.2 and <= 4.8.8 into this site."
 msgstr ""
 
 #: textpattern-importer.php:86

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Plugin Name ===
 Contributors: wordpressdotorg
-Donate link: 
+Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
-Tested up to: 4.1
-Stable tag: trunk
+Tested up to: 6.1
+Stable tag: 0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,15 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3 =
+* Fix: add support for PHP 7.2
+* Fix: remove call to `set_magic_quotes_runtime`
+
+= 0.2 =
+* Add WP_LOAD_IMPORTERS check
+* Add I18N for importers
+* Add license header
 
 = 0.1 =
 * Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
 Tested up to: 6.1
-Stable tag: 0.3
+Stable tag: 0.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.1 =
+* Add support for TextPattern >= 4.0.2 and <= 4.8.8
 
 = 0.3 =
 * Fix: add support for PHP 7.2

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -70,7 +70,11 @@ class Textpattern_Import extends WP_Importer {
 	function header()
 	{
 		echo '<div class="wrap">';
-		screen_icon();
+
+		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			screen_icon();
+		}
+
 		echo '<h2>'.__('Import Textpattern', 'textpattern-importer').'</h2>';
 		echo '<p>'.__('Steps may take a few minutes depending on the size of your database. Please be patient.', 'textpattern-importer').'</p>';
 	}

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -71,7 +71,7 @@ class Textpattern_Import extends WP_Importer {
 	{
 		echo '<div class="wrap">';
 
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.3
-Stable tag: 0.3
+Version: 0.3.1
+Stable tag: 0.3.1
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.2
-Stable tag: 0.2
+Version: 0.3
+Stable tag: 0.3
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -202,8 +202,8 @@ class Textpattern_Import extends WP_Importer {
 
 
 				// Make Nice Variables
-				$name = $wpdb->escape($name);
-				$title = $wpdb->escape($title);
+				$name = esc_sql($name);
+				$title = esc_sql($title);
 
 				if($cinfo = category_exists($name))
 				{
@@ -242,8 +242,8 @@ class Textpattern_Import extends WP_Importer {
 				extract($user);
 
 				// Make Nice Variables
-				$name = $wpdb->escape($name);
-				$RealName = $wpdb->escape($RealName);
+				$name = esc_sql($name);
+				$RealName = esc_sql($RealName);
 
 				if($uinfo = get_userdatabylogin($name))
 				{
@@ -323,9 +323,9 @@ class Textpattern_Import extends WP_Importer {
 				$uinfo = ( get_userdatabylogin( $AuthorID ) ) ? get_userdatabylogin( $AuthorID ) : 1;
 				$authorid = ( is_object( $uinfo ) ) ? $uinfo->ID : $uinfo ;
 
-				$Title = $wpdb->escape($Title);
-				$Body = $wpdb->escape($Body);
-				$Excerpt = $wpdb->escape($Excerpt);
+				$Title = esc_sql($Title);
+				$Body = esc_sql($Body);
+				$Excerpt = esc_sql($Excerpt);
 				$post_status = $stattrans[$Status];
 
 				// Import Post data into WordPress
@@ -409,10 +409,10 @@ class Textpattern_Import extends WP_Importer {
 				$comment_ID = ltrim($discussid, '0');
 				$comment_post_ID = $postarr[$parentid];
 				$comment_approved = (1 == $visible) ? 1 : 0;
-				$name = $wpdb->escape($name);
-				$email = $wpdb->escape($email);
-				$web = $wpdb->escape($web);
-				$message = $wpdb->escape($message);
+				$name = esc_sql($name);
+				$email = esc_sql($email);
+				$web = esc_sql($web);
+				$message = esc_sql($message);
 
 				$comment = array(
 							'comment_post_ID'	=> $comment_post_ID,
@@ -465,9 +465,9 @@ class Textpattern_Import extends WP_Importer {
 				extract($link);
 
 				// Make nice vars
-				$category = $wpdb->escape($category);
-				$linkname = $wpdb->escape($linkname);
-				$description = $wpdb->escape($description);
+				$category = esc_sql($category);
+				$linkname = esc_sql($linkname);
+				$description = esc_sql($description);
 
 				if($linfo = link_exists($linkname))
 				{
@@ -629,39 +629,35 @@ class Textpattern_Import extends WP_Importer {
 		{
 			check_admin_referer('import-textpattern');
 
-			if($_POST['dbuser'])
-			{
+			if ( ! empty( $_POST['dbuser'] ) ) {
 				if(get_option('txpuser'))
 					delete_option('txpuser');
-				add_option('txpuser', sanitize_user($_POST['dbuser'], true));
+				add_option('txpuser', sanitize_user( $_POST['dbuser'], true));
 			}
-			if($_POST['dbpass'])
-			{
+
+			if ( ! empty( $_POST['dbpass'] ) ) {
 				if(get_option('txppass'))
 					delete_option('txppass');
 				add_option('txppass',  sanitize_user($_POST['dbpass'], true));
 			}
 
-			if($_POST['dbname'])
-			{
+			if ( ! empty( $_POST['dbname'] ) ) {
 				if(get_option('txpname'))
 					delete_option('txpname');
 				add_option('txpname',  sanitize_user($_POST['dbname'], true));
 			}
-			if($_POST['dbhost'])
-			{
+
+			if ( ! empty( $_POST['dbhost'] ) ) {
 				if(get_option('txphost'))
 					delete_option('txphost');
 				add_option('txphost',  sanitize_user($_POST['dbhost'], true));
 			}
-			if($_POST['dbprefix'])
-			{
+
+			if ( ! empty( $_POST['dbprefix'] ) ) {
 				if(get_option('tpre'))
 					delete_option('tpre');
 				add_option('tpre',  sanitize_user($_POST['dbprefix']));
 			}
-
-
 		}
 
 		switch ($step)


### PR DESCRIPTION
This PR upgrades the plugin to `0.3`.

1. Tested with WordPress `6.1`
2. Tested with PHP `7.4.33`
3. Add additional check for WordPress >= 3.8.0
4. https://github.com/WordPress/textpattern-importer/pull/1
5. https://github.com/WordPress/textpattern-importer/pull/2

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **TextPattern Importer**
5. Open `http://localhost/wp-admin/admin.php?import=textpattern`
6. The plugin must load correctly and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/textpattern-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
