### PR TITLE
Testing the plugin up to WordPress 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
-Tested up to: 6.1
+Tested up to: 6.2
 Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
 Tested up to: 6.1
-Stable tag: 0.3.1
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.2 =
+* Testing the plugin up to WordPress 6.2
 
 = 0.3.1 =
 * Add support for TextPattern >= 4.0.2 and <= 4.8.8

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.3.1
-Stable tag: 0.3.1
+Version: 0.3.2
+Stable tag: 0.3.2
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 


### PR DESCRIPTION
This PR upgrades the plugin to `0.3.2`.

1. Tested with WordPress `6.2`
2. Tested with PHP `7.4.33`

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **TextPattern Importer**
5. Open `http://localhost/wp-admin/admin.php?import=textpattern`
6. The plugin must load correctly and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/textpattern-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
