### PR TITLE
Test plugin for WordPress 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
 Tested up to: 6.3
-Stable tag: 0.3.3
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,9 +25,6 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
-
-= 0.3.3 =
-* Testing the plugin up to WordPress 6.3
 
 = 0.3.2 =
 * Testing the plugin up to WordPress 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
-Tested up to: 6.2
-Stable tag: 0.3.2
+Tested up to: 6.3
+Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.3 =
+* Testing the plugin up to WordPress 6.3
 
 = 0.3.2 =
 * Testing the plugin up to WordPress 6.2

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: https://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.3.3
-Stable tag: 0.3.3
+Version: 0.3.2
+Stable tag: 0.3.2
 License: GPL v2 - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: https://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.3.2
-Stable tag: 0.3.2
+Version: 0.3.3
+Stable tag: 0.3.3
 License: GPL v2 - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 


### PR DESCRIPTION
In this PR, we test the plugin for WordPress 6.3.

## How to test

1. Clone this PR
2. Using `wp-env` run an instance. The minimum PHP version is 7.0 because WordPress 6.3 [dropped support for PHP 5](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).
3. SSH to your instance and install the Textpattern CMS. ([documentation](https://textpattern.com/start#installation))
4. Login to Textpattern and generate some data.
5. Go to `http://localhost:8888/wp-admin/admin.php?import=textpattern` and insert the database settings used on Textpattern.
6. Check if the content has been imported and no errors are being generated.