### PR TITLE
Update tested up to label and stable tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
-Tested up to: 6.3
-Stable tag: 0.3.2
+Tested up to: 6.4.2
+Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,10 @@ Import categories, users, posts, comments, and links from a TextPattern blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.3 =
+* Testing the plugin up to WordPress 6.4.2
+* Update link references from http to https.
 
 = 0.3.2 =
 * Testing the plugin up to WordPress 6.2

--- a/textpattern-importer.php
+++ b/textpattern-importer.php
@@ -5,8 +5,8 @@ Plugin URI: https://wordpress.org/extend/plugins/textpattern-importer/
 Description: Import categories, users, posts, comments, and links from a TextPattern blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.3.2
-Stable tag: 0.3.2
+Version: 0.3.3
+Stable tag: 0.3.3
 License: GPL v2 - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 


### PR DESCRIPTION
- This PR test for WordPress 6.4.2 with PHP 7.0, 7.4 and 8.0.
- Since there was changes gets merged and not bumping the version previously, we also need to taking care of it and bumping the version to `0.3.3` here.
- Related changes: https://github.com/WordPress/textpattern-importer/pull/5

### How to test

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "7.0",
  "plugins": ["./textpattern-importer"]
}
```
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=textpattern` and perform an import
- Check and see if the import works fine without errors