### PR TITLE
Update tested up to label

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, textpattern
 Requires at least: 3.0
-Tested up to: 6.4.2
+Tested up to: 6.7
 Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.7.

Tested with WordPress 6.7
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is blogger-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./textpattern-importer"]
}
```
3. Run `wp-env start` to spin up the WordPress
4. Install Textpattern 4.8.8 and create some content ([documentation](https://textpattern.com/start#installation))

Navigate to `http://localhost:8888/wp-admin/admin.php?import=textpattern`. 

If you have some problem with your credentials you will probably get: `Warning: mysqli_real_connect(): (HY000/2002): No such file or directory in /var/www/html/wp-includes/class-wpdb.php on line 1982 No such file or directory`. It's a warning that appears only with `WP_DEBUG`. Be sure that `Textpattern Database Host` is ok.

Check that all is imported without errors and warnings.